### PR TITLE
Add benchmarking utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,11 @@ dependencies = [
  "bonfida-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "borsh",
  "bytemuck",
+ "lazy_static",
  "pyth-client",
+ "regex",
+ "serde",
+ "serde_json",
  "solana-client",
  "solana-program",
 ]
@@ -387,6 +391,16 @@ dependencies = [
  "fs_extra",
  "proc-macro2 1.0.34",
  "syn 1.0.83",
+]
+
+[[package]]
+name = "cargo-benchviz"
+version = "0.1.0"
+dependencies = [
+ "gnuplot",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1030,6 +1044,15 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
+name = "gnuplot"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de437277a7ec10de5f34e3147c7da4c6d8b279c5d8ae1e33e842fd9432bb0f3"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "h2"
@@ -2172,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["utils", "macros", "autobindings", "autodoc", "autoproject"]
+members = ["utils", "macros", "autobindings", "autodoc", "autoproject", "benchviz"]
 exclude = ["TOBEREPLACEDBY_KEBAB"]

--- a/benchviz/Cargo.toml
+++ b/benchviz/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cargo-benchviz"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+gnuplot = "0.0.37"
+serde = {version = "1", features = ["derive"]}
+serde_json = "1"
+regex = "1"

--- a/benchviz/src/main.rs
+++ b/benchviz/src/main.rs
@@ -1,0 +1,68 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fs::{read_dir, DirBuilder, File},
+};
+
+use gnuplot::{Figure, PlotOption};
+use regex::Regex;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Measures {
+    commit_id: String,
+    x: Vec<u64>,
+    y: Vec<u64>,
+}
+fn main() {
+    let current_directory = std::env::current_dir().unwrap();
+    let results_directory = current_directory.join("benchmark_results");
+    if !results_directory.is_dir() {
+        eprintln!("Couldn't find the benchmark results directory");
+        return;
+    }
+
+    let graph_output_path = results_directory.join("graphs");
+    if graph_output_path.is_file() {
+        eprintln!("Delete the graphs benchmark_results/graphs file");
+        return;
+    }
+
+    let files = read_dir(&results_directory).unwrap();
+    let mut figures = HashMap::new();
+    let file_name_re = Regex::new("(?P<test_name>.*)_(?P<commit_id>[^_]*)").unwrap();
+    for f in files {
+        let path = f.unwrap().path();
+        if !path.is_file() {
+            continue;
+        }
+        let file = File::open(&path).unwrap();
+        let c = file_name_re
+            .captures(path.file_stem().unwrap().to_str().unwrap())
+            .unwrap();
+        let test_name = &c["test_name"];
+        println!("{test_name}");
+        let figure_entry = figures.entry(test_name.to_owned());
+        let figure = match figure_entry {
+            Entry::Occupied(o) => o.into_mut(),
+            Entry::Vacant(o) => o
+                .insert(Figure::new())
+                .set_title(&test_name.replace('_', "\\_")),
+        };
+        let measures: Measures = serde_json::from_reader(file).unwrap();
+        figure.axes2d().lines_points(
+            &measures.x,
+            &measures.y,
+            &[PlotOption::Caption(
+                &String::from_utf8(measures.commit_id.into_bytes()[0..7].to_owned()).unwrap(),
+            )],
+        );
+    }
+    if !graph_output_path.is_dir() {
+        let dir_builder = DirBuilder::new();
+        dir_builder.create(&graph_output_path).unwrap();
+    }
+    for (name, mut fig) in figures {
+        let path = graph_output_path.join(&format!("{name}.png"));
+        fig.save_to_png(&path, 1920, 1080).unwrap();
+    }
+}

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [features]
 instruction_params_casting = ["bonfida-macros/instruction_params_casting", "bytemuck"]
 mock-oracle = []
+benchmarking = ["lazy_static", "regex", "serde", "serde_json"]
 
 [dependencies]
 borsh = "0.9"
@@ -18,6 +19,10 @@ solana-program = "1.8"
 pyth-client = {version="0.5.0", features= ["no-entrypoint"]}
 bonfida-macros = "0.2.3"
 bytemuck = {version = "1.7.2", optional=true}
+lazy_static = {version = "1.4.0", optional=true}
+regex = {version = "1.5.5", optional=true}
+serde = {version = "1.0.136", features=["derive"], optional=true}
+serde_json = {version = "1.0.79",  optional=true}
 
 [dev-dependencies]
 solana-client = "1.9"

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -1,0 +1,102 @@
+use std::{
+    fs::{DirBuilder, File},
+    process::Output,
+};
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::Serialize;
+use solana_program::pubkey::Pubkey;
+
+#[derive(Serialize)]
+pub struct Measures {
+    test_name: String,
+    commit_id: String,
+    x: Vec<u64>,
+    y: Vec<u64>,
+}
+
+impl Measures {
+    pub fn save(&self, output_file: File) {
+        serde_json::to_writer(output_file, &self).unwrap();
+    }
+}
+
+pub fn get_commit_id() -> String {
+    let o = std::process::Command::new("git")
+        .arg("log")
+        .output()
+        .unwrap()
+        .stdout;
+    let end = o.iter().position(|s| *s == 10 || *s == 13).unwrap();
+    let output = String::from_utf8(o[0..end].to_owned()).unwrap();
+    lazy_static! {
+        static ref RE: Regex = Regex::new("commit (.*)").unwrap();
+    }
+    RE.captures(&output).unwrap()[1].to_owned()
+}
+
+pub fn is_working_tree_clean() -> bool {
+    let o = std::process::Command::new("git")
+        .arg("diff")
+        .arg("HEAD")
+        .output()
+        .unwrap()
+        .stdout;
+    o.is_empty()
+}
+
+pub fn get_output_file(test_name: &str, commit_id: &str) -> Option<File> {
+    let current_directory = std::env::current_dir().unwrap();
+    let output_dir = current_directory.join("benchmark_results");
+    if output_dir.is_file() {
+        panic!("Delete or rename the benchmark_results file");
+    }
+    if !output_dir.exists() {
+        let d = DirBuilder::new();
+        d.create(&output_dir).unwrap();
+    }
+    let file_path = output_dir.join(&format!("{}_{}.json", test_name, commit_id));
+    if file_path.exists() {
+        return None;
+    }
+
+    Some(File::create(file_path).unwrap())
+}
+
+pub struct LogParser {
+    re: Regex,
+}
+
+impl LogParser {
+    pub fn new(program_id: Pubkey) -> Self {
+        Self {
+            re: Regex::new(&format!(
+                "Program {} consumed (?P<val>.*) of .* compute units\n",
+                program_id
+            ))
+            .unwrap(),
+        }
+    }
+
+    pub fn parse(&self, output: Output) -> Vec<u64> {
+        let output = String::from_utf8(output.stderr).unwrap();
+        let c = self.re.captures_iter(&output).collect::<Vec<_>>();
+        let res = c
+            .iter()
+            .map(|k| k["val"].parse::<u64>().unwrap())
+            .collect::<Vec<_>>();
+        res
+    }
+}
+
+#[macro_export]
+macro_rules! test_name {
+    () => {
+        std::path::Path::new(file!())
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap();
+    };
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,3 +13,6 @@ pub mod pyth;
 pub use accounts::InstructionsAccount;
 pub use bonfida_macros::{declare_id_with_central_state, BorshSize, InstructionsAccount};
 pub use borsh_size::BorshSize;
+
+#[cfg(feature = "benchmarking")]
+pub mod bench;


### PR DESCRIPTION
This PR aims to create a few utilities to begin the buildup of a proper bonfida-utils benchmarking framework. The end game is to create an automated process which records performance statistics in a reliable and reproducible way for each commit.