### PR TITLE
Add rounding-direction aware fp bindings. Force deprecate old bindings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,14 +104,23 @@ dependencies = [
  "anyhow",
  "bs58 0.3.1",
  "heck 0.3.3",
- "proc-macro2 1.0.42",
+ "proc-macro2 1.0.43",
  "proc-macro2-diagnostics",
- "quote 1.0.20",
+ "quote 1.0.21",
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "syn 1.0.98",
+ "syn 1.0.99",
  "thiserror",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -125,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "arrayref"
@@ -160,7 +169,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -169,9 +178,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "synstructure",
 ]
 
@@ -181,9 +190,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -221,9 +230,9 @@ version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -243,14 +252,14 @@ version = "0.1.0"
 dependencies = [
  "anchor-syn",
  "cargo_toml",
- "clap 3.2.16",
+ "clap 3.2.17",
  "convert_case",
  "hex",
- "proc-macro2 1.0.42",
+ "proc-macro2 1.0.43",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "syn 1.0.98",
+ "syn 1.0.99",
  "utf8",
 ]
 
@@ -264,25 +273,25 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "autodoc"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
  "convert_case",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "rustfmt-wrapper",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "autoproject"
 version = "0.1.1"
 dependencies = [
- "clap 3.2.16",
+ "clap 3.2.17",
  "convert_case",
  "fs_extra",
  "include_dir",
  "path-absolutize",
- "proc-macro2 1.0.42",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -299,16 +308,16 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
+checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
 
 [[package]]
 name = "benchviz"
 version = "0.1.0"
 dependencies = [
  "bonfida-utils",
- "clap 3.2.16",
+ "clap 3.2.17",
  "gnuplot",
  "regex",
  "serde",
@@ -382,10 +391,10 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 name = "bonfida-macros"
 version = "0.2.5"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "solana-program",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -394,10 +403,10 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f5ace5ed40eb56cd6d6a0de41bc2e919af6047d98f7e502d06fa201a7814ad4"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "solana-program",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -414,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "bonfida-utils"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "bonfida-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "borsh",
@@ -448,8 +457,8 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.42",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -458,9 +467,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -469,9 +478,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -509,9 +518,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "bv"
@@ -525,22 +534,22 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd2f4180c5721da6335cc9e9061cce522b87a35e51cc57636d28d22a9863c80"
+checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -578,11 +587,10 @@ dependencies = [
 
 [[package]]
 name = "caps"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bf7211aad104ce2769ec05efcdfabf85ee84ac92461d142f22cf8badd0e54c"
+checksum = "938c50180feacea622ef3b8f4a496057c868dcf8ac7a64d781dd8f3f51a9c143"
 dependencies = [
- "errno",
  "libc",
  "thiserror",
 ]
@@ -615,23 +623,25 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "chrono-humanize"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb"
+checksum = "32dce1ea1988dbdf9f9815ff11425828523bd2a134ec0805d2ac8af26ee6096e"
 dependencies = [
  "chrono",
 ]
@@ -672,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -703,7 +713,7 @@ dependencies = [
  "autodoc",
  "autoproject",
  "benchviz",
- "clap 3.2.16",
+ "clap 3.2.17",
 ]
 
 [[package]]
@@ -789,9 +799,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -1012,9 +1022,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1042,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "eager"
@@ -1094,16 +1104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07b7cc9cd8c08d10db74fca3b20949b9b6199725c04a0cce6d543496098fcac"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -1135,9 +1145,9 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1148,10 +1158,10 @@ checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "rustc_version",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1161,9 +1171,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1177,27 +1187,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1267,9 +1256,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1282,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1292,15 +1281,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1309,38 +1298,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1365,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "serde",
  "typenum",
@@ -1421,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91766b1121940d622933a13e20665857648681816089c9bc2075c4b75a6e4f6b"
+checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
 dependencies = [
  "log",
  "plain",
@@ -1432,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1632,6 +1621,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,8 +1675,8 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
 ]
 
 [[package]]
@@ -1740,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -1791,9 +1793,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -1912,9 +1914,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -1999,9 +2001,9 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2087,9 +2089,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2159,10 +2161,10 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
- "proc-macro-crate 1.2.0",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro-crate 1.2.1",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2191,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"
@@ -2228,15 +2230,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "ouroboros"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020e5088e4600e6b82e7c192de0d04c1f37d5b3cfd8dfec193cec1f81f15fa0"
+checksum = "55190d158a4c09a30bdb5e3b2c50a37f299b8dd9f59d0e1510782732e8bf8877"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -2244,15 +2246,15 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df194bd9cdca62dad63764c2185d1a23b38a11582db74275847c45f99d440725"
+checksum = "816c4556bb87c05aad7710d02e88ed50a93f837d73dfe417ec5e890a9e1bbec7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2365,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2375,22 +2377,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2457,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d50bfb8c23f23915855a00d98b5a35ef2e0b871bb52937bacadb798fbb66c8"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
  "once_cell",
  "thiserror",
@@ -2473,9 +2475,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "version_check",
 ]
 
@@ -2485,8 +2487,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "version_check",
 ]
 
@@ -2501,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -2514,9 +2516,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "version_check",
  "yansi",
 ]
@@ -2562,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7542006acd6e057ff632307d219954c44048f818898da03113d6c0086bfddd9"
+checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2581,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a13a5c0a674c1ce7150c9df7bc4a1e46c2fbbe7c710f56c0dc78b1a810e779e"
+checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
 dependencies = [
  "bytes",
  "fxhash",
@@ -2601,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3149f7237331015f1a6adf065c397d1be71e032fcf110ba41da52e7926b882f"
+checksum = "9f832d8958db3e84d2ec93b5eb2272b45aa23cf7f8fe6e79f578896f4e6c231b"
 dependencies = [
  "futures-util",
  "libc",
@@ -2624,11 +2626,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2 1.0.42",
+ "proc-macro2 1.0.43",
 ]
 
 [[package]]
@@ -2743,7 +2745,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.12",
+ "time 0.3.14",
  "yasna",
 ]
 
@@ -2818,7 +2820,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile 1.0.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2879,7 +2881,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.12",
+ "semver 1.0.13",
 ]
 
 [[package]]
@@ -2923,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile 1.0.1",
  "schannel",
  "security-framework",
 ]
@@ -2939,24 +2941,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64 0.13.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -2995,10 +2997,10 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "serde_derive_internals",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -3022,9 +3024,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -3039,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3071,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "semver-parser"
@@ -3086,31 +3088,31 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.141"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af873f2c95b99fcb0bd0fe622a43e29514658873c8ceba88c4cb88833a22500"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.141"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75743a150d003dd863b51dc809bcad0d73f2102c53632f1e954e738192a3413f"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -3119,16 +3121,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -3236,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
 
 [[package]]
 name = "sized-chunks"
@@ -3277,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902dcb6659eece65b2049cbe43aa29e364493d4afe5341583671d6941d3ccdfa"
+checksum = "dce4b5bb907e16e5947f621dc009ced9687f1f86460a7171caf3fff90e7df62f"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -3301,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9c6e8e5161b42e2836af7b822bdd517bca844242a69bb686fe9f12ca06b911"
+checksum = "91cf5ed23f166b543744156bc1c466499fa32f06e3b650f38213e1475a8a19b5"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3322,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ad811182bbdd980bbc2b1e5c43c0ebb9567278d933663f1a5a29ccb9b95ac4"
+checksum = "611ff0690cba260e46645f530e1a2eafc373055ae894d0f9ab45c9e32bc92e6b"
 dependencies = [
  "borsh",
  "futures",
@@ -3339,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d47998fa03097b3ee32a4aad12d74e182d8420dce87aca4f76c264fba33312"
+checksum = "b3722ec2744cdfb7bef7f8346f6006a90ea919f67417e2928fd293d375ab254b"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -3350,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0067ac8167745e0c70029a8558e28deb2348ef2858b74542d8d479f5512d4191"
+checksum = "b172732fa3f53d89128588f7728b2a3e382c5192badcee6f3e1caef705ddab76"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -3370,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550c8cd45221e2110f43230294a33efbf9bfecf9c8c7933aa4fdd531a684567a"
+checksum = "e315a81529a00e5b5323c21aa0f37911397538ab19272663f6fcd1278c627c36"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3389,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1beaf6242a5c4038b9bae479fd38238c50fc3df92ba7b899c4658f4de961b30d"
+checksum = "8c968f5cd8f9385ed442bbbadc89af5a59124df402a3002362ab110f976eed5f"
 dependencies = [
  "log",
  "memmap2",
@@ -3404,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2740cd65b05b8dd2fb1cc77dc2200d665d1dae3497ee865efcb5a70039d8a6"
+checksum = "bd4d2269e63c833c268d60eb913b5eee8b5611454529849af40b59d5b9363688"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -3422,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bd7fb10f240172abf77da5a45b5d9bbb9293ffe8df73d8670374e5a69c3735"
+checksum = "b315c3301f79cbf9df85942d2509ffb8066de65061ae75f5f621895cb14b358f"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3438,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e771bffae33df269977f89739f33400281d16847d995d837e7af20031368e4d5"
+checksum = "8f48fd618bda1129817d297af9f85251c6988342537b64a8f6ea7ef581c938e4"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -3466,7 +3468,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "rustls",
- "semver 1.0.12",
+ "semver 1.0.13",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3492,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c148c03368c9d38df7509d0918194be5269443fc963791b20b31f5e39f8c516"
+checksum = "2f97c04ff8c451ac0d060d6eaddeec9148af897df581504734480ff56457ffdc"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -3502,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e72e2154a06e25129bf3f58e509e10cbd728bd77f00c95623b9fa119920e246"
+checksum = "b2048eea8ae237e2343b45fde49269b2e7592aba5bf77edac050f3754e0558ef"
 dependencies = [
  "bincode",
  "chrono",
@@ -3516,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8232d861d015b3d10319aaf4bbe9857895378367b8f6e58a6154215fe409fb3c"
+checksum = "3332a624612ae3d0185ae22c6c80a37b35c0035005d20d45b2d188d8a2dcc493"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3540,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f74f824ec967c5f2ad8b486a26324f0be49c9181563b1937df19b9b4c04283"
+checksum = "853bb08e658cfef8a2cab32459539b238fbaac9d5f34a916867f51467092e12e"
 dependencies = [
  "ahash",
  "blake3",
@@ -3574,21 +3576,21 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7785df5d63b5be3d2278ee63a2e2d5e6baf4a48dac0a76b9700b94480ce5780d"
+checksum = "bbdc3ca4b60d9b9ec0474f745a8a0e8317440f148dc4910c8b045d86ad83f0ed"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "rustc_version",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47da97ef3afe8993766cbe45896c2c7c8a2664d2b6d54907795650cd1aca778"
+checksum = "4edef304d4b316e45690db8251f55683a6bca3d13b1ba19a73e9c15e4fdc2d9b"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3597,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693ed856618c9cbc94ad1693e47c4d248efb156cfd75e372a5ad960fd870f26f"
+checksum = "c4b62868c28eec5b0d56a9df00c944770e35809ba04c9d726983fea8ab6828fc"
 dependencies = [
  "log",
  "solana-sdk",
@@ -3607,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701941851b4d1088e94c852dc2616893ae06e6c7f36a1ec22be8cd283d01f9a4"
+checksum = "00cd6c24b0579454936ad77c626fd169b9145731ee13105037c23a21a1539cca"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -3621,12 +3623,12 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6a92e678581cefa4d3ef9ce54705ca6b372c081d1d918d02da277730b7946e"
+checksum = "392a1abc4eeb2ebb979c2e35e35fd737debd347ea5d437fe0269edfc963880a3"
 dependencies = [
  "bincode",
- "clap 3.2.16",
+ "clap 3.2.17",
  "crossbeam-channel",
  "log",
  "nix",
@@ -3643,9 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310ada2030ee86ad023a687b1491285677e2dd38fc40769b306981dac76bf38e"
+checksum = "2913b26e8c0b91243cb811af349078bee0fb25599c4c3e4404d985d85cfbfbb7"
 dependencies = [
  "ahash",
  "bincode",
@@ -3670,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc09933c74d7a42a4e3da42e329f7c68c11be8a615d0e89da052800c66a3f782"
+checksum = "cbc3839dd967928f16f138d42f718212e99d15fc15b26ebef104277d9809775e"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3719,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e32800a658a353b8f63e7b1b917c17b54aa925604c6f4e4d66020924e3e3583"
+checksum = "5291c5f1ee60f5f4c3a6636a3f712a5b5d0293d1a6e623842e57555b4bd411db"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3745,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72c1263dae9bf4ad5a492ca94fa9cb597d73f70d299945772018e6320af936f"
+checksum = "144036e34758f052f58e1bb78a55b4bfeec05480e147ddea2cf453159e0ade9e"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3770,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5524b3aba1a6e8080e65a96137bfb7eb3d14188e29cc649d2e8fc7d5a094c5eb"
+checksum = "88ae954be57c13d33dfe980340ea195c138aff4c03149c3daf2d66ad2267dadd"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3780,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c461dcfc4425de5505ca9a1d8a3f5a4afcf2a1853f040f8ecc1926b8d55f33"
+checksum = "25eb84b7e9868fbbd305e75ef32d068bdbc206d85a43e7c0881eac47a21d2108"
 dependencies = [
  "console",
  "dialoguer",
@@ -3791,7 +3793,7 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.1",
  "qstring",
- "semver 1.0.12",
+ "semver 1.0.13",
  "solana-sdk",
  "thiserror",
  "uriparse",
@@ -3799,9 +3801,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb581bc778cdf935da633c2dc843c1c4dc11bffe3267f5db4d7b846b8b3a9c0"
+checksum = "874e83d1131bf9b0aeb2aa8aac2bd16e65b898ab7c8618189f6abde971bc8d31"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3859,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d44f0b3a8f47cbceb027039b133d2c66053ce93d9e00a6d73b4c1e346d0e3d"
+checksum = "d9017cf106b3a645f098ace248c849002f594773a4a9a0e4570ed4c9e063a140"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -3910,22 +3912,22 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91d47ca86a0cb8255145a436c59f9a0cd22464f352f61a47f6b57a160d8ccb4"
+checksum = "a39cae167a571797569bbc9c679412591f7a0a091a1ac1b636b5f16a4b3d1ad0"
 dependencies = [
  "bs58 0.4.0",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "rustversion",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80597fcdc895b3b964d7493eafc672e9bc9cfc729d4d8a9c28edb063cca90e0c"
+checksum = "fd94c2a24f9764dd4527b3b5d4d999abe8e8ff4ed5274b06ba3b4638316cf05f"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -3938,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a4e8db8871c02759ee166705cf191bfea337ef63614de55516fc10176f55b9"
+checksum = "7533ecba4ddd4c25afd5b7a8b745ef111e5a6e40498fb1b35810954070e13a08"
 dependencies = [
  "bincode",
  "log",
@@ -3961,9 +3963,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf67359ad1ea5190f655c86e7cc84564e2ffd1f86dc31c1c0679e0b6bb2b72bd"
+checksum = "28681e0ab441d6695a2409c12ed28f02bf5860c95c2cda894a0ce98412feb5c1"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -3990,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3728f15387e9458e47e7e1f2965604141544985c5537df85b9f529b097cb2f6"
+checksum = "19b4967154d08c34e7bea63f187036a380a938c8f25d6cf7d2c110dd147c0bf2"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
@@ -4007,7 +4009,6 @@ dependencies = [
  "solana-account-decoder",
  "solana-measure",
  "solana-metrics",
- "solana-runtime",
  "solana-sdk",
  "solana-vote-program",
  "spl-associated-token-account",
@@ -4019,13 +4020,13 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872f04434ffcec53ad229c0a021e0cc5af044d9e31456b09e5d205ad66660f40"
+checksum = "e7c18123a16461f0c6b8d14712174b34548f480e6cd9686eba3ab4496198e18c"
 dependencies = [
  "log",
  "rustc_version",
- "semver 1.0.12",
+ "semver 1.0.13",
  "serde",
  "serde_derive",
  "solana-frozen-abi",
@@ -4035,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd4b8a2a2104d17a90e58ca115743c3c5eaa080d72d6ae6ce0e11114625da0b"
+checksum = "7ac0d44002afc2e9c1143a1bab8ba2384e9dda10695afa2ab19f43bc207fc345"
 dependencies = [
  "bincode",
  "log",
@@ -4056,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c056dc215328e193017c597eebf6bd98f77da6c6b114c98dbf11116ad101e00"
+checksum = "b60c77d4d4d41f278c1109e2ea29f6f93879708125b21114576f42873d75e5cc"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
@@ -4071,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.11.4"
+version = "1.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1227f90f0d8750114d2e2009b3414cdb688b8aed5e69809f3c85340e450af6b7"
+checksum = "258fb750d39c9dee375e43559189124aec32b028b54b1f3494f9a8ff5ef82cee"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -4135,13 +4136,18 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b013067447a1396303ddfc294f36e3d260a32f8a16c501c295bcdc7de39b490"
+checksum = "16a33ecc83137583902c3e13c02f34151c8b2f2b74120f9c2b3ff841953e083d"
 dependencies = [
+ "assert_matches",
  "borsh",
+ "num-derive",
+ "num-traits",
  "solana-program",
  "spl-token",
+ "spl-token-2022",
+ "thiserror",
 ]
 
 [[package]]
@@ -4155,11 +4161,12 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc67166ef99d10c18cb5e9c208901e6d8255c6513bb1f877977eba48e6cc4fb"
+checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
 dependencies = [
  "arrayref",
+ "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
@@ -4169,9 +4176,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f001b3579e69a695a22e458fa1a4b76ab25a142544a094e3f65af63dc61c2f"
+checksum = "f0a97cbf60b91b610c846ccf8eecca96d92a24a19ffbf9fe06cd0c84e76ec45e"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -4214,15 +4221,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "rustversion",
- "syn 1.0.98",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -4250,12 +4257,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
  "unicode-ident",
 ]
 
@@ -4265,9 +4272,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "unicode-xid 0.2.3",
 ]
 
@@ -4312,9 +4319,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -4367,22 +4374,22 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -4407,12 +4414,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa",
- "js-sys",
  "libc",
  "num_threads",
  "time-macros",
@@ -4484,9 +4490,9 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -4619,9 +4625,9 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -4706,9 +4712,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -4884,9 +4890,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -4908,7 +4914,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
- "quote 1.0.20",
+ "quote 1.0.21",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4918,9 +4924,9 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5058,7 +5064,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.12",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -5091,7 +5097,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "time 0.3.12",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -5109,9 +5115,9 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "synstructure",
 ]
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonfida-utils"
-version = "0.2.14"
+version = "0.3.0"
 authors = ["ellttBen <elliott@bonfida.com>"]
 description = "Various solana program writing utilities in use by Bonfida."
 license = "MIT"

--- a/utils/src/fp_math.rs
+++ b/utils/src/fp_math.rs
@@ -1,57 +1,88 @@
+use std::convert::TryInto;
+
 pub const FP_32_ONE: u64 = 1 << 32;
 
 /// a is fp0, b is fp32 and result is a/b fp0
 pub fn fp32_div(a: u64, b_fp32: u64) -> Option<u64> {
     ((a as u128) << 32)
         .checked_div(b_fp32 as u128)
-        .and_then(safe_downcast)
+        .and_then(|x| x.try_into().ok())
 }
 
 /// a is fp0, b is fp32 and result is a*b fp0
-pub fn fp32_mul(a: u64, b_fp32: u64) -> Option<u64> {
+pub fn fp32_mul_floor(a: u64, b_fp32: u64) -> Option<u64> {
     (a as u128)
         .checked_mul(b_fp32 as u128)
-        .and_then(|x| safe_downcast(x >> 32))
+        .and_then(|x| (x >> 32).try_into().ok())
+}
+
+/// a is fp0, b is fp32 and result is a*b fp0
+pub fn fp32_mul_ceil(a: u64, b_fp32: u64) -> Option<u64> {
+    (a as u128)
+        .checked_mul(b_fp32 as u128)
+        .and_then(fp32_ceil_util)
+        .and_then(|x| (x >> 32).try_into().ok())
 }
 
 /// a is fp0, b is fp32 and result is a/b fp0
 pub fn ifp32_div(a: i64, b_fp32: u64) -> Option<i64> {
-    ((a.abs() as u128) << 32)
+    ((a.unsigned_abs() as u128) << 32)
         .checked_div(b_fp32 as u128)
-        .and_then(safe_downcast)
-        .map(|x| a.signum() * (x as i64))
+        .and_then(|x| x.try_into().ok())
+        .map(|x: i64| a.signum() * x)
 }
 
 /// a is fp0, b is fp32 and result is a*b fp0
-pub fn ifp32_mul(a: i64, b_fp32: u64) -> Option<i64> {
-    (a.abs() as u128)
+pub fn ifp32_mul_floor(a: i64, b_fp32: u64) -> Option<i64> {
+    (a.unsigned_abs() as u128)
         .checked_mul(b_fp32 as u128)
-        .and_then(|x| safe_downcast(x >> 32))
-        .map(|x| a.signum() * x as i64)
+        .and_then(|x| (x >> 32).try_into().ok())
+        .map(|x: i64| a.signum() * x)
+}
+
+/// a is fp0, b is fp32 and result is a*b fp0
+pub fn ifp32_mul_ceil(a: i64, b_fp32: u64) -> Option<i64> {
+    (a.unsigned_abs() as u128)
+        .checked_mul(b_fp32 as u128)
+        .and_then(fp32_ceil_util)
+        .and_then(|x| (x >> 32).try_into().ok())
+        .map(|x: i64| a.signum() * x)
 }
 
 /// a is fp0, b is fp64 and result is a/b fp0
 pub fn fp64_div(a: u64, b_fp64: u64) -> Option<u64> {
     ((a as u128) << 64)
         .checked_div(b_fp64 as u128)
-        .and_then(safe_downcast)
+        .and_then(|x| x.try_into().ok())
 }
 
 /// a is fp0, b is fp64 and result is a*b fp0
-pub fn fp64_mul(a: u64, b_fp64: u64) -> Option<u64> {
+pub fn fp64_mul_floor(a: u64, b_fp64: u64) -> Option<u64> {
     (a as u128)
         .checked_mul(b_fp64 as u128)
         .map(|x| (x >> 64))
-        .and_then(safe_downcast)
+        .and_then(|x| x.try_into().ok())
 }
 
-pub fn safe_downcast(n: u128) -> Option<u64> {
-    static BOUND: u128 = u64::MAX as u128;
-    if n > BOUND {
-        None
-    } else {
-        Some(n as u64)
-    }
+/// a is fp0, b is fp64 and result is a*b fp0
+pub fn fp64_mul_ceil(a: u64, b_fp64: u64) -> Option<u64> {
+    (a as u128)
+        .checked_mul(b_fp64 as u128)
+        .map(|x| (x >> 64))
+        .and_then(fp64_ceil_util)
+        .and_then(|x| x.try_into().ok())
+}
+
+#[inline(always)]
+fn fp32_ceil_util(x_fp32: u128) -> Option<u128> {
+    let add_one = (!(x_fp32 as u32)).wrapping_add(1) as u128;
+    x_fp32.checked_add(add_one)
+}
+
+#[inline(always)]
+fn fp64_ceil_util(x_fp64: u128) -> Option<u128> {
+    let add_one = (!(x_fp64 as u64)).wrapping_add(1) as u128;
+    x_fp64.checked_add(add_one)
 }
 
 #[test]
@@ -61,22 +92,35 @@ fn test() {
     assert_eq!(fp32_div(124345678765454, 6787654 << 32).unwrap(), 18319389);
 
     // fp32_mul
-    assert_eq!(fp32_mul(5676543, 6787654 << 32).unwrap(), 38530409800122);
-    assert_eq!(fp32_mul(12454, 45654 << 32).unwrap(), 568574916);
+    assert_eq!(
+        fp32_mul_floor(5676543, 6787654 << 32).unwrap(),
+        38530409800122
+    );
+    assert_eq!(fp32_mul_floor(12454, 45654 << 32).unwrap(), 568574916);
+    assert_eq!(fp32_mul_floor(5, 1 << 31).unwrap(), 2);
+    assert_eq!(
+        fp32_mul_ceil(5676543, 6787654 << 32).unwrap(),
+        38530409800122
+    );
+    assert_eq!(fp32_mul_ceil(12454, 45654 << 32).unwrap(), 568574916);
+    assert_eq!(fp32_mul_ceil(5, 1 << 31).unwrap(), 3);
 
     // ifp32_div
     assert_eq!(ifp32_div(124345678765454, 6787654 << 32).unwrap(), 18319389);
     assert_eq!(ifp32_div(124345678765454, 45654 << 32).unwrap(), 2723653541);
 
     // ifp32_mul
-    assert_eq!(ifp32_mul(5676543, 6787654 << 32).unwrap(), 38530409800122);
-    assert_eq!(ifp32_mul(12454, 45654 << 32).unwrap(), 568574916);
+    assert_eq!(
+        ifp32_mul_floor(5676543, 6787654 << 32).unwrap(),
+        38530409800122
+    );
+    assert_eq!(ifp32_mul_floor(12454, 45654 << 32).unwrap(), 568574916);
 
     // fp64_div
     assert_eq!(fp64_div(5676543, 345678909876543456).unwrap(), 302921968);
     assert_eq!(fp64_div(12454, 345678909876543456).unwrap(), 664592);
 
     // fp64_mul
-    assert_eq!(fp64_mul(5676543, 345678909876543456).unwrap(), 106374);
-    assert_eq!(fp64_mul(12454, 345678909876543456).unwrap(), 233)
+    assert_eq!(fp64_mul_floor(5676543, 345678909876543456).unwrap(), 106374);
+    assert_eq!(fp64_mul_floor(12454, 345678909876543456).unwrap(), 233)
 }

--- a/utils/src/pyth.rs
+++ b/utils/src/pyth.rs
@@ -1,4 +1,3 @@
-use crate::fp_math::safe_downcast;
 use pyth_sdk_solana::{
     state::{
         load_mapping_account, load_price_account, load_product_account, CorpAction, PriceStatus,
@@ -7,6 +6,7 @@ use pyth_sdk_solana::{
     Price,
 };
 use solana_program::{msg, program_error::ProgramError, pubkey::Pubkey};
+use std::convert::TryInto;
 #[cfg(feature = "mock-oracle")]
 use std::convert::TryInto;
 
@@ -79,7 +79,7 @@ pub fn get_oracle_price_fp32(
     let corrected_price =
         (price * 10u128.pow(quote_decimals as u32)) / 10u128.pow(base_decimals as u32);
 
-    let final_price = safe_downcast(corrected_price).unwrap();
+    let final_price = corrected_price.try_into().unwrap();
 
     msg!("Pyth FP32 price value: {:?}", final_price);
 


### PR DESCRIPTION
This PR aims to encourage fp_math users to be aware of rounding by having different bindings for different binding directions.