### PR TITLE
autobindings: use `bigint` instead of `bn.js`

### DIFF
--- a/crates/autobindings/src/js_generate.rs
+++ b/crates/autobindings/src/js_generate.rs
@@ -185,7 +185,7 @@ fn type_to_js(ty: &Type) -> String {
             match simple_type.as_ref() {
                 "bool" => "boolean".to_owned(),
                 "u8" | "u16" | "u32" | "i8" | "i16" | "i32" => "number".to_owned(),
-                "u64" | "u128" | "i64" | "i128" => "BN".to_owned(),
+                "u64" | "u128" | "i64" | "i128" => "bigint".to_owned(),
                 "String" => "string".to_owned(),
                 "Pubkey" => "Uint8Array".to_owned(),
                 "Vec" => {
@@ -244,7 +244,7 @@ fn array_to_js(inner_type: &str) -> String {
     match inner_type as &str {
         "\"u8\"" | "\"i8\"" => "Uint8Array",
         "\"u16\"" | "\"i16\"" | "\"u32\"" | "\"i32\"" => "number[]",
-        "\"u64\"" | "\"i64\"" | "\"u128\"" | "\"i128\"" => "BN[]",
+        "\"u64\"" | "\"i64\"" | "\"u128\"" | "\"i128\"" => "bigint[]",
         _ => unimplemented!(),
     }
     .to_owned()

--- a/crates/autobindings/src/templates/template.ts
+++ b/crates/autobindings/src/templates/template.ts
@@ -1,6 +1,5 @@
 // This file is auto-generated. DO NOT EDIT
-import BN from "bn.js";
-import { Schema, serialize } from "borsh";
+import { serialize } from "borsh";
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 
 export interface AccountKey {

--- a/crates/autobindings/src/test.rs
+++ b/crates/autobindings/src/test.rs
@@ -148,7 +148,6 @@ pub fn test(instructions_path: &str) {
         let mut js_test_file = File::create("../js/tmp_test.ts").unwrap();
         let mut js_test_str = format!(
             "import {{ PublicKey }} from \"@solana/web3.js\";
-            import BN from \"bn.js\";
             import {{ {}Instruction }} from \"./src/raw_instructions\";",
             snake_to_camel(&module_name)
         );
@@ -225,7 +224,7 @@ fn type_to_test_input(ty: &Type, rng: &mut ThreadRng, array: bool) -> Vec<TestIn
                         {
                             input + ","
                         } else {
-                            "new BN(".to_owned() + &input + "),"
+                            "BigInt(".to_owned() + &input + "),"
                         },
                     }]
                 }


### PR DESCRIPTION
borsh >= 1.0.0 relies on `bigint` instead of `bn.js` (borsh <= 0.7.0)