### PR TITLE
Update README.md installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install the main bonfida cli
 ```
 git clone https://github.com/Bonfida/bonfida-utils.git
 cd bonfida-utils
-cargo install --path cli
+cargo install --path crates/cli
 ```
 
 To automatically generate Javascript or Python bindings


### PR DESCRIPTION
Changed the path to the cli crate

OLD:
git clone https://github.com/Bonfida/bonfida-utils.git cd bonfida-utils
cargo install --path cli

NEW:
git clone https://github.com/Bonfida/bonfida-utils.git cd bonfida-utils
cargo install --path crates/cli